### PR TITLE
fix: Serialize weights to dict for MCP JSON response

### DIFF
--- a/bl_mcp/tools.py
+++ b/bl_mcp/tools.py
@@ -581,7 +581,7 @@ def optimize_portfolio_bl(
         perf = (portfolio_return, portfolio_vol, sharpe)
 
     result = {
-        "weights": weights,
+        "weights": weights.to_dict() if hasattr(weights, 'to_dict') else dict(weights),
         "expected_return": perf[0],
         "volatility": perf[1],
         "sharpe_ratio": perf[2],


### PR DESCRIPTION
## Summary
- Fix "Unable to serialize unknown type: pandas.core.series.Series" error when calling `optimize_portfolio_bl` without views
- Convert `weights` to dict before returning to ensure JSON serialization works

## Problem
When views are provided, `bl.bl_weights()` returns `OrderedDict` (JSON serializable).
When views are NOT provided, `mcaps / mcaps.sum()` returns `pandas.Series` (NOT JSON serializable).

## Solution
Add `.to_dict()` conversion to weights before returning, ensuring consistent JSON-serializable output in all cases.

## Test plan
- [ ] Call `optimize_portfolio_bl` without views → should return JSON with weights as dict
- [ ] Call `optimize_portfolio_bl` with views → should still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)